### PR TITLE
Increase async stream task delay

### DIFF
--- a/AsyncStreams/Program.cs
+++ b/AsyncStreams/Program.cs
@@ -18,7 +18,7 @@ namespace AsyncStreams
         {
             for (int i = 0; i < 20; i++)
             {
-                await Task.Delay(100);
+                await Task.Delay(250);
                 yield return i;
             }
         }


### PR DESCRIPTION
To make the demonstration more believable the delay between each iterator yield should be increased to 250 ms.